### PR TITLE
docstrings, refactor "tags"

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -23,6 +23,13 @@ pub struct ClientCliArgs {
     pub address: String,
 }
 
+/// Unconditionally set `GameState` for each `SetGameState` event read
+///
+/// NOTE: This could be done on the server as well and we could forget
+/// about the server writing its own state separately. In that case, is
+/// ToClient a reasonable name for the event? (probably still yes)
+///
+/// refactor_tags: to_client_read, game_state_write
 pub fn handle_set_game_state(
     mut game_state: ResMut<State<resources::GameState>>,
     mut to_client_events: EventReader<events::ToClient>,
@@ -35,6 +42,11 @@ pub fn handle_set_game_state(
     }
 }
 
+/// Insert `GameConfig` for each `SetGameConfig` event read
+///
+/// NOTE: Could we insert this on the server too a la `GameState`??
+///
+/// refactor_tags: to_client_read, commands, game_config_insert
 pub fn handle_set_game_config(
     mut commands: Commands,
     mut to_client_events: EventReader<events::ToClient>,
@@ -46,6 +58,11 @@ pub fn handle_set_game_config(
     }
 }
 
+/// Send every `ToServer` event read, over the network to the server
+///
+/// NOTE: Definitely only on "client"
+///
+/// refactor_tags: to_server_read, network_client_write
 pub fn send_messages_to_server(
     mut to_server_events: EventReader<events::ToServer>,
     mut client: ResMut<RenetClient>,
@@ -58,6 +75,11 @@ pub fn send_messages_to_server(
     }
 }
 
+/// For every `ToClient` received over the network from the server, send it as an event
+///
+/// NOTE: Only "client" but, the server lacks this analog for its client-on-server.
+///
+/// refactor_tags: network_client_write, to_client_write
 pub fn receive_messages_from_server(
     mut client: ResMut<RenetClient>,
     mut to_client_events: EventWriter<events::ToClient>,
@@ -72,6 +94,11 @@ use bevy_egui::{
     EguiContext,
 };
 
+/// Read various resources and display a toggleable info screen
+///
+/// NOTE: This system can tolerate absence of `GameConfig`, since this is available before its insertion.
+///
+/// refactor_tags: ui_state_read, game_state_read, game_config_read, cameras_read, network_client_read, egui, gui
 pub fn info_text(
     mut ctx: ResMut<EguiContext>,
     ui_state: Res<resources::UiState>,
@@ -162,6 +189,9 @@ pub fn info_text(
         });
 }
 
+/// Cleverly position the "objective" camera to get a good view of the masses, using only the masses as input.
+///
+/// refactor_tags: cameras_write, mass_id_read, gui
 pub fn position_objective_camera(
     masses: Query<&Transform, With<components::MassID>>,
     mut cameras: Query<
@@ -183,7 +213,7 @@ pub fn position_objective_camera(
             let furthest_two = furthest_two.update(&positions);
             if let Some(triplet_cross) = furthest_two.get_farthest_triplet_normal() {
                 let camera_translation_direction = triplet_cross.normalize();
-                // FIXME: points.0 is `Some` becaues `get_farthest_triplet_normal()` is `Some`.
+                // FIXME: points.0 is `Some` because `get_farthest_triplet_normal()` is `Some`.
                 // A better way forward: Make a type that represents all the masses at a frozen
                 // point in time `(mass, location)` and provide methods like `get_centroid()`
                 // on downward. We needen't leave people wondering, "What is 'triplet_cross'?"
@@ -199,6 +229,9 @@ pub fn position_objective_camera(
     }
 }
 
+/// Set the `UiState` resource based upon user input
+///
+/// refactor_tags: ui_state_write, user_input
 pub fn set_ui_state(mut ui_state: ResMut<resources::UiState>, keys: Res<Input<KeyCode>>) {
     if keys.just_released(KeyCode::O) {
         ui_state.camera = match ui_state.camera {
@@ -211,6 +244,13 @@ pub fn set_ui_state(mut ui_state: ResMut<resources::UiState>, keys: Res<Input<Ke
     }
 }
 
+/// Set the active camera based upon `UiState`
+///
+/// NOTE: Some kind of "assurance" that we have exactly one camera for each
+/// of the `CameraTag` values, that only one is active at any time and that
+/// the current active camera matches `UiState`.
+///
+/// refactor_tags: ui_state_read, camera_write, testing
 pub fn set_active_camera(
     ui_state: Res<resources::UiState>,
     mut cameras: Query<(&mut Camera, &resources::CameraTag)>,
@@ -227,6 +267,11 @@ pub fn set_active_camera(
     }
 }
 
+/// For `client_id`, and `address` supplied by caller, create and return `RenetClient`.
+///
+/// NOTE: Insertion of the `RenetClient` resource triggers the connection process.
+///
+/// refactor_tags: network_client_insert
 pub fn new_renet_client(client_id: u64, address: String) -> RenetClient {
     let address = if let Ok(address) = format!("{address}").parse() {
         address
@@ -251,6 +296,9 @@ pub fn new_renet_client(client_id: u64, address: String) -> RenetClient {
     .unwrap()
 }
 
+/// Set a helpful window title
+///
+/// refactor_tags: gui, windows_write, network_client_read
 pub fn set_window_title(mut windows: ResMut<Windows>, client: Res<RenetClient>) {
     let title = "Mass Gathering";
     let id = client.client_id();
@@ -259,6 +307,9 @@ pub fn set_window_title(mut windows: ResMut<Windows>, client: Res<RenetClient>) 
     windows.primary_mut().set_title(title);
 }
 
+/// Set window resolution
+///
+/// refactor_tags: gui, windows_write, startup_system
 pub fn set_resolution(mut windows: ResMut<Windows>) {
     let window = windows.primary_mut();
     if cfg!(debug_assertions) {
@@ -269,6 +320,10 @@ pub fn set_resolution(mut windows: ResMut<Windows>) {
     }
 }
 
+/// Spawn one camera for each possible `CameraTag` value, ensure only one is active.
+/// Insert the corresponding `CameraTag` marker component into each newly-spawned camera.
+///
+/// refactor_tags: gui, commands, startup_system, testing
 pub fn spawn_cameras(mut commands: Commands) {
     for tag in &[
         resources::CameraTag::Client,
@@ -289,6 +344,9 @@ pub fn spawn_cameras(mut commands: Commands) {
     }
 }
 
+/// Spawn some reasonable directional lights to light masses.
+///
+/// refactor_tags: gui, commands, startup_system
 pub fn let_light(mut commands: Commands) {
     debug!("Adding some directional lighting (distant suns)");
     commands.spawn(DirectionalLightBundle {
@@ -311,6 +369,11 @@ pub fn let_light(mut commands: Commands) {
     });
 }
 
+/// Rotate inhabited mass based upon user input, write `ToServer::Rotation` with the _net_ rotation.
+///
+/// NOTE: The server broadcasts the current rotation to all _other_ clients, which they use to update their simulation.
+///
+/// refactor_tags: gui, user_input, to_server_write, inhabited_mass_write, time,
 pub fn control(
     keys: Res<Input<KeyCode>>,
     time: Res<Time>,
@@ -362,6 +425,9 @@ pub fn control(
     }
 }
 
+/// For every `ProjectileSpawned` received from the simulation, insert a `PbrBundle` to make it visible.
+///
+/// refactor_tags: gui, commands, meshes, materials, from_simulation_read
 pub fn visualize_projectiles(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -401,6 +467,9 @@ pub fn visualize_projectiles(
     }
 }
 
+/// Show sights for uninhabited mass, send `ToServer::ProjectileFired` when user fires.
+///
+/// refactor_tags: gui, uninhabited_mass_read, sights_write, inhabited_mass_read, rapier_context_read, user_input, to_server_write
 pub fn handle_projectile_engagement(
     mass_query: Query<
         (&Transform, &components::MassID),
@@ -458,6 +527,7 @@ pub fn handle_projectile_engagement(
     }
 }
 
+/// refactor_tags: UNSET
 pub fn visualize_masses(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,8 @@
+/// The client module
+///
+/// "Client" is currently defined as: the networking, gui (windows), and simulation parts put together to play the game, on a network.
+/// Contrast "server", is a networking server, which requires a full simulation, and also can _optionally_ do the graphical stuff or
+/// be headless.
 use bevy_rapier3d::prelude::{QueryFilter, RapierContext};
 use bevy_renet::{
     renet::{ClientAuthentication, DefaultChannel, RenetClient, RenetConnectionConfig},

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,3 +1,4 @@
+/// The executable client binary
 use bevy::prelude::App;
 
 fn main() {

--- a/client/src/plugins.rs
+++ b/client/src/plugins.rs
@@ -1,3 +1,4 @@
+/// Plugin(s) required to implement a server binary (executable).
 use crate::*;
 use bevy_egui::EguiPlugin;
 use clap::Parser;

--- a/client/src/plugins.rs
+++ b/client/src/plugins.rs
@@ -4,6 +4,7 @@ use bevy_egui::EguiPlugin;
 use clap::Parser;
 
 #[derive(Default)]
+/// refactor_tags: UNSET
 pub struct ClientPlugin;
 
 impl Plugin for ClientPlugin {

--- a/game/src/components.rs
+++ b/game/src/components.rs
@@ -1,3 +1,4 @@
+/// Components common to all packages (sort of)
 use crate::*;
 use bevy::prelude::Component;
 

--- a/game/src/events.rs
+++ b/game/src/events.rs
@@ -1,10 +1,4 @@
-// FIXME:
-//
-// Maybe make better use of channel characteristics?
-//
-//  - Rotate -> Unreliable
-//  - InitData -> Chunk
-
+/// All events used by the game, independant of package (sort of)
 use crate::*;
 use bevy::prelude::Component;
 use serde::{Deserialize, Serialize};

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -1,3 +1,4 @@
+/// Functionality common to all packages
 use bevy::ecs::schedule::ShouldRun;
 pub use bevy::prelude::*;
 use bevy_renet::renet::RenetError;

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -19,36 +19,44 @@ pub const SERVER_PORT: u16 = 5743;
 
 // NOTE: Density is assumed to be 1.0 everywhere, so mass and volume are used interchangably.
 
+/// refactor_tags: UNSET
 pub fn radius_to_mass(radius: f32) -> f32 {
     (3.0 / 4.0) * TAU * radius.powf(3.0)
 }
 
+/// refactor_tags: UNSET
 pub fn mass_to_radius(mass: f32) -> f32 {
     ((mass * (4.0 / 3.0)) / TAU).powf(1.0 / 3.0)
 }
 
+/// refactor_tags: UNSET
 pub fn scale_to_radius(scale: Vec3) -> f32 {
     // TODO: Should assert that it's a uniform scale.
     scale.x // arbitrary axis
 }
 
+/// refactor_tags: UNSET
 pub fn radius_to_scale(radius: f32) -> Vec3 {
     Vec3::splat(radius)
 }
 
+/// refactor_tags: UNSET
 pub fn scale_to_mass(scale: Vec3) -> f32 {
     radius_to_mass(scale_to_radius(scale))
 }
 
+/// refactor_tags: UNSET
 pub fn mass_to_scale(mass: f32) -> Vec3 {
     radius_to_scale(mass_to_radius(mass))
 }
 
+/// refactor_tags: UNSET
 pub fn to_nick(id: u64) -> String {
     let nic_vec: Vec<u8> = id.to_ne_bytes().to_vec();
     String::from_utf8(nic_vec).unwrap() // NOTE includes trailing spaces
 }
 
+/// refactor_tags: UNSET
 pub fn from_nick(nick: &str) -> u64 {
     let mut nick_vec = [b' '; 8];
     if nick.len() > 8 {
@@ -60,6 +68,7 @@ pub fn from_nick(nick: &str) -> u64 {
     u64::from_ne_bytes(nick_vec)
 }
 
+/// refactor_tags: UNSET
 pub fn with_gravity(
     game_config: Option<Res<resources::GameConfig>>,
     game_state: Res<State<resources::GameState>>,
@@ -74,6 +83,7 @@ pub fn with_gravity(
     ShouldRun::No
 }
 
+/// refactor_tags: UNSET
 pub fn get_log_plugin(package: &str) -> bevy::log::LogPlugin {
     if cfg!(debug_assertions) {
         let filter = format!("info,wgpu_core=warn,wgpu_hal=off,{package}=debug");
@@ -84,12 +94,14 @@ pub fn get_log_plugin(package: &str) -> bevy::log::LogPlugin {
     }
 }
 
+/// refactor_tags: UNSET
 pub fn panic_on_renet_error(mut renet_error: EventReader<RenetError>) {
     for e in renet_error.iter() {
         panic!("Renet error: {e:?}");
     }
 }
 
+/// refactor_tags: UNSET
 pub fn game_has_started(
     game_config: Option<Res<resources::GameConfig>>,
     game_state: Res<State<resources::GameState>>,

--- a/game/src/physics.rs
+++ b/game/src/physics.rs
@@ -9,6 +9,7 @@ use bevy_rapier3d::prelude::{ActiveEvents, Collider, CollisionEvent, RigidBody, 
 #[derive(Debug)]
 pub struct MassCollisionEvent(pub Entity, pub Entity);
 
+/// refactor_tags: UNSET
 pub fn handle_mass_collisions(
     mut collision_events: EventReader<CollisionEvent>,
     mut mass_collision_events: EventWriter<MassCollisionEvent>,
@@ -26,6 +27,7 @@ pub fn handle_mass_collisions(
 
 pub struct DespawnMassEvent(pub Entity);
 
+/// refactor_tags: UNSET
 pub fn handle_despawn_mass(
     mut commands: Commands,
     mut despawn_mass_events: EventReader<DespawnMassEvent>,
@@ -43,6 +45,7 @@ pub fn handle_despawn_mass(
 // * Define and implement an "extension type" so you can `set_mass()` and
 //   `get_mass` on type `Transform` (using `scale`).
 
+/// refactor_tags: UNSET
 pub fn merge_masses(
     mut mass_query: Query<(&mut Transform, &mut components::Momentum, Entity)>,
     inhabitant_query: Query<
@@ -135,6 +138,7 @@ impl Default for PointMassBundle {
     }
 }
 
+/// refactor_tags: UNSET
 pub fn freefall(
     mut masses_query: Query<(Entity, &mut Transform, &mut components::Momentum)>,
     game_config: Res<resources::GameConfig>,

--- a/game/src/physics.rs
+++ b/game/src/physics.rs
@@ -1,3 +1,8 @@
+/// Physics!!
+///
+/// Oribity stuff and mass-mass collision stuff (the latter disabled for now).
+///
+/// Maybe this goes in "simulation"?
 use crate::*;
 use bevy_rapier3d::prelude::{ActiveEvents, Collider, CollisionEvent, RigidBody, Sensor};
 

--- a/game/src/plugins.rs
+++ b/game/src/plugins.rs
@@ -1,3 +1,4 @@
+/// Plugins common to all packages
 use crate::*;
 use bevy_rapier3d::prelude::{NoUserData, RapierConfiguration, RapierPhysicsPlugin};
 

--- a/game/src/plugins.rs
+++ b/game/src/plugins.rs
@@ -3,6 +3,7 @@ use crate::*;
 use bevy_rapier3d::prelude::{NoUserData, RapierConfiguration, RapierPhysicsPlugin};
 
 #[derive(Default)]
+/// refactor_tags: UNSET
 pub struct CorePlugin;
 
 impl Plugin for CorePlugin {
@@ -17,6 +18,7 @@ impl Plugin for CorePlugin {
 }
 
 #[derive(Default)]
+/// refactor_tags: UNSET
 pub struct SimulationPlugin;
 
 // FIXME: The mass-mass collision and merging code has been disabled. This

--- a/game/src/resources.rs
+++ b/game/src/resources.rs
@@ -1,3 +1,6 @@
+/// Resources regardless of package (sort of).
+/// Things that are both `Component` and `Resource` also
+/// go here (I think).
 use crate::*;
 
 use serde::{Deserialize, Serialize};

--- a/game/src/resources.rs
+++ b/game/src/resources.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Copy, Serialize, Deserialize)]
+/// refactor_tags: UNSET
 pub enum GameState {
     Running, // full networked game play
     Waiting, // waiting for clients
@@ -26,6 +27,7 @@ impl std::fmt::Display for GameState {
 }
 
 #[derive(Serialize, Deserialize, Resource, Debug, Copy, Clone)]
+/// refactor_tags: UNSET
 pub struct PhysicsConfig {
     pub speed: u32,
     pub zerog: bool,
@@ -41,12 +43,14 @@ impl Default for PhysicsConfig {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Copy, Debug)]
+/// refactor_tags: UNSET
 pub struct MassMotion {
     pub position: Vec3,
     pub velocity: Vec3,
 }
 
 #[derive(Default, Serialize, Deserialize, Resource, Debug, Copy, Clone)]
+/// refactor_tags: UNSET
 pub struct MassInitData {
     pub inhabitable: bool,
     pub motion: MassMotion,
@@ -68,11 +72,13 @@ impl From<MassInitData> for Transform {
 }
 
 #[derive(Default, Serialize, Deserialize, Resource, Debug, Clone)]
+/// refactor_tags: UNSET
 pub struct InitData {
     pub masses: HashMap<u64, MassInitData>,
 }
 
 #[derive(Default, Serialize, Deserialize, Resource, Debug, Clone)]
+/// refactor_tags: UNSET
 pub struct GameConfig {
     pub client_mass_map: HashMap<u64, u64>,
     pub physics_config: PhysicsConfig,
@@ -119,6 +125,7 @@ impl GameConfig {
 // Both a `Resource`, because it is used in `UiState`, and also
 // a `Component` because it is used to mark camera entities.
 #[derive(Resource, Debug, Component, PartialEq, Clone)]
+/// refactor_tags: UNSET
 pub enum CameraTag {
     Client,
     Objective,
@@ -145,6 +152,7 @@ impl std::fmt::Display for CameraTag {
 }
 
 #[derive(Resource, Debug)]
+/// refactor_tags: UNSET
 pub struct UiState {
     pub camera: CameraTag,
     pub show_info: bool,

--- a/game/src/simulation.rs
+++ b/game/src/simulation.rs
@@ -96,6 +96,7 @@ pub fn handle_game_config_insertion(
     }
 }
 
+/// refactor_tags: UNSET
 pub fn handle_projectile_fired(
     mut commands: Commands,
     mut to_client_events: EventReader<events::ToClient>,
@@ -117,6 +118,7 @@ pub fn handle_projectile_fired(
     }
 }
 
+/// refactor_tags: UNSET
 pub fn move_projectiles(
     mut commands: Commands,
     mut projectile_query: Query<(Entity, &mut Transform, &events::ProjectileFlight)>,
@@ -165,6 +167,7 @@ pub fn move_projectiles(
     }
 }
 
+/// refactor_tags: UNSET
 pub fn handle_projectile_collision(
     mut collision_events: EventReader<CollisionEvent>,
     projectile_query: Query<&events::ProjectileFlight>,
@@ -190,6 +193,7 @@ pub fn handle_projectile_collision(
     }
 }
 
+/// refactor_tags: UNSET
 pub fn get_centroid(masses: Vec<(f32, Vec3)>) -> Vec3 {
     let total_mass = masses
         .iter()
@@ -200,6 +204,7 @@ pub fn get_centroid(masses: Vec<(f32, Vec3)>) -> Vec3 {
 }
 
 #[derive(Debug)]
+/// refactor_tags: UNSET
 pub struct FurthestTwo {
     pub points: (Option<Vec3>, Option<Vec3>),
     pub reference: Vec3,

--- a/game/src/simulation.rs
+++ b/game/src/simulation.rs
@@ -1,3 +1,4 @@
+/// Everything minus the visuals. Move stuff, spawn stuff, but nothing that's not headless.
 use crate::*;
 use bevy_rapier3d::prelude::{Collider, CollisionEvent, RigidBody};
 use bevy_renet::renet::RenetClient;

--- a/game/src/simulation.rs
+++ b/game/src/simulation.rs
@@ -38,6 +38,17 @@ pub enum FromSimulation {
     },
 }
 
+/// React to the insertion of the GameConfig resource.
+///   * Iterate through the masses and spawn `TransformBundle`s that are
+///   the basis of the simulation. These are "invisible" such that we can
+///   skip all GUI stuff and use this in a "headless" sense.
+///   * Conditionally handle "inhabited" and complicated stuff.
+///   * Emit an event for each new entity. Other systems can respond by.
+///   Upgrading them to "visible" so they can be rendered and displayed.
+///   * We do not care about seeing them but we do care how "big" they are
+///   because we insert a `Collider`.
+///
+/// refactor_tags: simulation, running, eventwriter, client
 pub fn handle_game_config_insertion(
     mut commands: Commands,
     game_config: Option<Res<resources::GameConfig>>,

--- a/game/src/systems/mod.rs
+++ b/game/src/systems/mod.rs
@@ -7,6 +7,7 @@
 use crate::*;
 use std::collections::HashMap;
 
+/// refactor_tags: UNSET
 pub fn demo_2m2i() -> resources::InitData {
     let mut init_data = resources::InitData::default();
     let position = Vec3::X * 10.0;
@@ -39,6 +40,7 @@ pub fn demo_2m2i() -> resources::InitData {
     init_data
 }
 
+/// refactor_tags: UNSET
 pub fn demo_shooting() -> resources::InitData {
     let mut init_data = resources::InitData::default();
     let id_base = 0;
@@ -82,6 +84,7 @@ pub fn demo_shooting() -> resources::InitData {
     init_data
 }
 
+/// refactor_tags: UNSET
 pub fn rando_calrissian() -> resources::InitData {
     resources::InitData {
         masses: HashMap::from([
@@ -559,6 +562,7 @@ pub fn rando_calrissian() -> resources::InitData {
     }
 }
 
+/// refactor_tags: UNSET
 pub fn cubic() -> resources::InitData {
     let mut init_data = resources::InitData::default();
 
@@ -637,6 +641,7 @@ pub fn cubic() -> resources::InitData {
     init_data
 }
 
+/// refactor_tags: UNSET
 pub fn get_system(name: &str) -> impl (Fn() -> resources::InitData) {
     match name {
         "cubic" => cubic,

--- a/game/src/systems/mod.rs
+++ b/game/src/systems/mod.rs
@@ -1,3 +1,9 @@
+/// Code for generating the various hand-built systems.
+///
+/// NOTE: I don't like "system" but here I mean roughly "solar system" not "bevy system", please post your ideas to my coordinates.
+///
+/// The way I think this should work: A separate package (?) provides tools to build serialized "systems" which you may write to disk if you like.
+/// The game can just somehow consume the serialized version, unpack, and proceed as before.
 use crate::*;
 use std::collections::HashMap;
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,6 @@
+/// Server stuff. Will/may include both "simulation" and "visual" stuff (for debugging).
+///
+/// But in this case there will be exactly zero instead of exactly one inhabited mass, should be optionally headless, and "reads its own output", i.e. anything that gets sent to clients also gets sent to this server's internal simulation (rotation does not matter). And it should be `x,y,z,v,m` exactly the same as the clients, or close enough.
 use bevy::app::AppExit;
 use bevy_renet::renet::ServerEvent;
 use bevy_renet::renet::{

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -14,6 +14,7 @@ use std::{net::UdpSocket, time::SystemTime};
 pub mod plugins;
 
 #[derive(Parser, Resource)]
+/// refactor_tags: UNSET
 pub struct ServerCliArgs {
     #[arg(long, default_value_t = 1)]
     pub speed: u32,
@@ -25,6 +26,7 @@ pub struct ServerCliArgs {
     pub zerog: bool,
 }
 
+/// refactor_tags: UNSET
 pub fn new_renet_server(address: String) -> RenetServer {
     let address = if let Ok(address) = format!("{address}").parse() {
         address
@@ -44,6 +46,7 @@ pub fn new_renet_server(address: String) -> RenetServer {
     .unwrap()
 }
 
+/// refactor_tags: UNSET
 pub fn handle_server_events(
     mut server_events: EventReader<ServerEvent>,
     mut server: ResMut<RenetServer>,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,4 @@
+/// The server binary (executable)
 use bevy::prelude::App;
 
 fn main() {

--- a/server/src/plugins.rs
+++ b/server/src/plugins.rs
@@ -1,3 +1,4 @@
+/// Plugin(s) required for server binary (executable)
 use crate::*;
 use bevy_renet::RenetServerPlugin;
 use clap::Parser;

--- a/server/src/plugins.rs
+++ b/server/src/plugins.rs
@@ -4,6 +4,7 @@ use bevy_renet::RenetServerPlugin;
 use clap::Parser;
 
 #[derive(Default)]
+/// refactor_tags: UNSET
 pub struct ServerPlugin;
 
 impl Plugin for ServerPlugin {


### PR DESCRIPTION
The plan was, and is still to annotate (just about) every type concerned with Bevy (mostly: systems, components, resources, events) with a line just before the type definition that begins `/// refactor_tags:`.

I've got a good start on a clear, meaningful set of tags that should lead to Great Insights about how to best organize the code. I'll maybe write a script to grep and parse all these, associate them with the type they refer to, and then do some "set" stuff, and general scheming about what all this reveals to me (🌈 🌈 )

I made good progress, got distracted on attempting "actual" docstrings, which is a whole nuther effort.

Merging into main and will maybe knock off the stragglers (the remaining 80%) as time permits. 

Helpful to know:

```
cargo doc --open --workspace --no-deps --document-private-items --lib --all-features
```

With this branch:

* All docs build (library module `client` conflicts with binary `client`, same with server)
* Actual docstrings for a dozen or so things.
* At least a `/// refactor_tags: UNSET` for things that need tagging.